### PR TITLE
Duration variable

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -3,17 +3,19 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/timjchin/unpuzzled"
 )
 
 type Config struct {
-	OtherString   string
-	CustomString  string
-	ThirdString   string
-	CustomBool    bool
-	CustomFloat64 float64
-	Int64Val      int64
+	OtherString    string
+	CustomString   string
+	ThirdString    string
+	CustomBool     bool
+	CustomFloat64  float64
+	CustomDuration time.Duration
+	Int64Val       int64
 }
 
 func main() {
@@ -27,6 +29,7 @@ func main() {
 			&unpuzzled.StringVariable{
 				Name:        "random-value",
 				Description: "Here's a random string",
+				Default:     "random",
 				Destination: &config.OtherString,
 			},
 			&unpuzzled.BoolVariable{
@@ -53,6 +56,11 @@ func main() {
 					Description: "An example required configuration variable.",
 				},
 				Type: unpuzzled.TomlConfig,
+			},
+			&unpuzzled.DurationVariable{
+				Name:        "test-duration",
+				Description: "An example time.Duration variable.",
+				Destination: &config.CustomDuration,
 			},
 		},
 		Action: func() {

--- a/examples/duration_variable/main.go
+++ b/examples/duration_variable/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/timjchin/unpuzzled"
+)
+
+func main() {
+	var duration time.Duration
+	app := unpuzzled.NewApp()
+	app.Command = &unpuzzled.Command{
+		Name:  "main",
+		Usage: "An example application that uses an unpuzzled.DurationVariable.",
+		Variables: []unpuzzled.Variable{
+			&unpuzzled.DurationVariable{
+				Name:        "test-duration",
+				Description: "An example time.Duration variable.",
+				Destination: &duration,
+				Default:     time.Second,
+			},
+		},
+		Action: func() {
+			fmt.Println("Duration has been parsed!", duration)
+		},
+	}
+
+	app.Run(os.Args)
+}

--- a/fixtures/basic_test.json
+++ b/fixtures/basic_test.json
@@ -4,6 +4,7 @@
         "test-string": "hi",
         "test-bool": true,
         "test-int": 5,
-        "test-int-64": 100
+        "test-int-64": 100,
+        "test-duration": "1h"
     }
 }

--- a/fixtures/basic_test.toml
+++ b/fixtures/basic_test.toml
@@ -4,3 +4,4 @@ teststring="hi"
 testbool=true
 testint=5
 testint64=100
+test-duration="15s"

--- a/variable_duration.go
+++ b/variable_duration.go
@@ -1,0 +1,88 @@
+package unpuzzled
+
+import (
+	"flag"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var zeroDuration = time.Duration(0)
+
+type DurationVariable struct {
+	Name            string
+	Description     string
+	Default         time.Duration
+	Required        bool
+	Destination     *time.Duration
+	flagDestination *time.Duration
+}
+
+func (d *DurationVariable) GetName() string {
+	return d.Name
+}
+
+func (d *DurationVariable) GetDescription() string {
+	return d.Description
+}
+
+func (d *DurationVariable) GetDestination() interface{} {
+	return d.Destination
+}
+
+func (d *DurationVariable) IsRequired() bool {
+	return d.Required
+}
+
+func (d *DurationVariable) GetDefault() (interface{}, bool) {
+	if d.Default == zeroDuration {
+		return zeroDuration, false
+	} else {
+		return d.Default, true
+	}
+}
+
+func (d *DurationVariable) apply(val interface{}) {
+	if duration, ok := val.(time.Duration); ok {
+		*d.Destination = duration
+	} else if stringVal, ok := val.(string); ok {
+		duration, err := time.ParseDuration(stringVal)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"err": err,
+			}).Fatal("Failed to parse time.Duration.")
+		}
+		*d.Destination = duration
+	}
+}
+
+func (d *DurationVariable) setDefaults() {
+	if d.Default != zeroDuration {
+		*d.Destination = d.Default
+	}
+}
+func (d *DurationVariable) setFlag(flagset *flag.FlagSet) {
+	var destination time.Duration
+	d.flagDestination = &destination
+	flagset.DurationVar(d.flagDestination, d.Name, d.Default, d.Description)
+}
+
+func (d *DurationVariable) getFlagValue(set *flag.FlagSet) (interface{}, bool) {
+	if *d.flagDestination == zeroDuration {
+		return nil, false
+	} else {
+		return *d.flagDestination, true
+	}
+}
+
+func (d *DurationVariable) setEnv(value string, envName string) (interface{}, bool) {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"err": err,
+			"environmentVariable": envName,
+		}).Fatal("Failed to parse time.Duration from Environment.")
+		return nil, false
+	}
+	return duration, true
+}


### PR DESCRIPTION
This PR adds a new `time.Duration` variable. 

In JSON and TOML, these need to be string values:

Most basic example:
```go
package main

import (
	"fmt"
	"os"
	"time"

	"github.com/timjchin/unpuzzled"
)

func main() {
	var duration time.Duration
	app := unpuzzled.NewApp()
	app.Command = &unpuzzled.Command{
		Name:  "main",
		Usage: "An example application that uses an unpuzzled.DurationVariable.",
		Variables: []unpuzzled.Variable{
			&unpuzzled.DurationVariable{
				Name:        "test-duration",
				Description: "An example time.Duration variable.",
				Destination: &duration,
				Default:     time.Second,
			},
		},
		Action: func() {
			fmt.Println("Duration has been parsed!", duration)
		},
	}

	app.Run(os.Args)
}
```

If a config variable is added, the durations should be strings:

TOML:
```toml
[main]
test-duration="15s"
```

JSON:
```json
{
    "main": {
        "test-duration": "15s"
    }
}
```