### PR TITLE
Fix toml.TomlTree reference to go-toml library

### DIFF
--- a/variable_config.go
+++ b/variable_config.go
@@ -79,7 +79,7 @@ func (c *ConfigVariable) getConfigValue(path string) (interface{}, error) {
 }
 
 type tomlConfig struct {
-	tree *toml.TomlTree
+	tree *toml.Tree
 }
 
 func (t *tomlConfig) GetByVariable(path string) (interface{}, error) {


### PR DESCRIPTION
Master branch of `https://github.com/pelletier/go-toml` don't have a `toml.TomlTree` field and has change its name to `toml.Tree` (https://github.com/pelletier/go-toml/blob/master/toml.go#L18).

It was used here https://github.com/timjchin/unpuzzled/blob/master/variable_config.go#L82__